### PR TITLE
refactor: move all enums into their own library, and expose them in the API

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -1,33 +1,9 @@
 import { EventEmitter } from 'events'
-import { AtemState, DVEEffect } from './lib/atemState'
+import { AtemState } from './lib/atemState'
 import { AtemSocket } from './lib/atemSocket'
+import { TransitionStyle, DVEEffect } from './enums'
 import AbstractCommand from './commands/AbstractCommand'
 import * as Commands from './commands'
-
-export enum Model {
-	TVS = 0x01,
-	OneME = 0x02,
-	TwoME = 0x03,
-	PS4K = 0x04,
-	OneME4K = 0x05,
-	TwoME4K = 0x06,
-	TwoMEBS4K = 0x07,
-	TVSHD = 0x08
-}
-
-export enum TransitionStyle {
-	MIX = 0x00,
-	DIP = 0x01,
-	WIPE = 0x02,
-	DVE = 0x03,
-	STING = 0x04
-}
-
-export enum TallyState {
-	None = 0x00,
-	Program = 0x01,
-	Preview = 0x02
-}
 
 export interface AtemOptions {
 	localPort?: number,

--- a/src/commands/MixEffects/Transition/TransitionDVECommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionDVECommand.ts
@@ -1,5 +1,6 @@
 import IAbstractCommand from '../../AbstractCommand'
-import { AtemState, DVEEffect } from '../../../lib/atemState'
+import { AtemState } from '../../../lib/atemState'
+import { DVEEffect } from '../../../enums'
 // import { Util } from '../../../lib/atemUtil'
 
 export class TransitionDVECommand implements IAbstractCommand {

--- a/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
+++ b/src/commands/MixEffects/Transition/TransitionPropertiesCommand.ts
@@ -1,6 +1,6 @@
 import IAbstractCommand from '../../AbstractCommand'
 import { AtemState } from '../../../lib/atemState'
-import { TransitionStyle } from '../../..'
+import { TransitionStyle } from '../../../enums'
 
 export class TransitionPropertiesCommand implements IAbstractCommand {
 	resolve: () => void

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -1,0 +1,81 @@
+export enum Model {
+	TVS = 0x01,
+	OneME = 0x02,
+	TwoME = 0x03,
+	PS4K = 0x04,
+	OneME4K = 0x05,
+	TwoME4K = 0x06,
+	TwoMEBS4K = 0x07,
+	TVSHD = 0x08
+}
+
+export enum TransitionStyle {
+	MIX = 0x00,
+	DIP = 0x01,
+	WIPE = 0x02,
+	DVE = 0x03,
+	STING = 0x04
+}
+
+export enum TallyState {
+	None = 0x00,
+	Program = 0x01,
+	Preview = 0x02
+}
+
+export enum ConnectionState {
+	None = 0x00,
+	SynSent = 0x01,
+	Established = 0x02,
+	Closed = 0x03
+}
+
+export enum PacketFlag {
+	AckRequest = 0x01,
+	Connect = 0x02,
+	Repeat = 0x04,
+	Error = 0x08,
+	AckReply = 0x10
+}
+
+export enum DVEEffect {
+	SwooshTopLeft= 0,
+	SwooshTop = 1,
+	SwooshTopRight = 2,
+	SwooshLeft = 3,
+	SwooshRight = 4,
+	SwooshBottomLeft = 5,
+	SwooshBottom = 6,
+	SwooshBottomRight = 7,
+
+	SpinCCWTopRight = 13,
+	SpinCWTopLeft = 8,
+	SpinCCWBottomRight = 15,
+	SpinCWBottomLeft = 10,
+	SpinCWTopRight = 9,
+	SpinCCWTopLeft = 12,
+	SpinCWBottomRight = 11,
+	SpinCCWBottomLeft = 14,
+
+	SqueezeTopLeft = 16,
+	SqueezeTop = 17,
+	SqueezeTopRight = 18,
+	SqueezeLeft = 19,
+	SqueezeRight = 20,
+	SqueezeBottomLeft = 21,
+	SqueezeBottom = 22,
+	SqueezeBottomRight = 23,
+
+	PushTopLeft = 24,
+	PushTop = 25,
+	PushTopRight = 26,
+	PushLeft = 27,
+	PushRight = 28,
+	PushBottomLeft = 29,
+	PushBottom = 30,
+	PushBottomRight = 31,
+
+	GraphicCWSpin = 32,
+	GraphicCCWSpin = 33,
+	GraphicLogoWipe = 34
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
 export * from './atem'
 export * from './lib/atemState'
+
+import * as Enums from './enums'
+export {
+	Enums
+}

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -2,22 +2,8 @@ import { createSocket, Socket } from 'dgram'
 import { EventEmitter } from 'events'
 import { Util } from './atemUtil'
 import { CommandParser } from './atemCommandParser'
+import { ConnectionState, PacketFlag } from '../enums'
 import AbstractCommand from '../commands/AbstractCommand'
-
-export enum ConnectionState {
-	None = 0x00,
-	SynSent = 0x01,
-	Established = 0x02,
-	Closed = 0x03
-}
-
-export enum PacketFlag {
-	AckRequest = 0x01,
-	Connect = 0x02,
-	Repeat = 0x04,
-	Error = 0x08,
-	AckReply = 0x10
-}
 
 export class AtemSocket extends EventEmitter {
 	private _connectionState = ConnectionState.Closed

--- a/src/lib/atemState.ts
+++ b/src/lib/atemState.ts
@@ -1,4 +1,4 @@
-import { Model, TransitionStyle } from '../atem'
+import { Model, TransitionStyle, DVEEffect } from '../enums'
 
 export class AtemState {
 	info = new DeviceInfo()
@@ -152,46 +152,4 @@ export class MediaState {
 	stillPool = {}
 	clipPool = {}
 	players: Array<{ playing: boolean, loop: boolean, atBeginning: boolean, clipFrame: number }> = []
-}
-
-export enum DVEEffect {
-	SwooshTopLeft= 0,
-	SwooshTop = 1,
-	SwooshTopRight = 2,
-	SwooshLeft = 3,
-	SwooshRight = 4,
-	SwooshBottomLeft = 5,
-	SwooshBottom = 6,
-	SwooshBottomRight = 7,
-
-	SpinCCWTopRight = 13,
-	SpinCWTopLeft = 8,
-	SpinCCWBottomRight = 15,
-	SpinCWBottomLeft = 10,
-	SpinCWTopRight = 9,
-	SpinCCWTopLeft = 12,
-	SpinCWBottomRight = 11,
-	SpinCCWBottomLeft = 14,
-
-	SqueezeTopLeft = 16,
-	SqueezeTop = 17,
-	SqueezeTopRight = 18,
-	SqueezeLeft = 19,
-	SqueezeRight = 20,
-	SqueezeBottomLeft = 21,
-	SqueezeBottom = 22,
-	SqueezeBottomRight = 23,
-
-	PushTopLeft = 24,
-	PushTop = 25,
-	PushTopRight = 26,
-	PushLeft = 27,
-	PushRight = 28,
-	PushBottomLeft = 29,
-	PushBottom = 30,
-	PushBottomRight = 31,
-
-	GraphicCWSpin = 32,
-	GraphicCCWSpin = 33,
-	GraphicLogoWipe = 34
 }


### PR DESCRIPTION
Currently, this places all enums into a single `enums/index.ts` file. However, this structure lets us easily break things up later on into more files, without needing to change any code which imports `enums/index.ts`.