### PR TITLE
refactor(AbstractCommand): make all methods optional

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -201,8 +201,10 @@ export class Atem extends EventEmitter {
 	}
 
 	private _mutateState (command: AbstractCommand) {
-		command.applyToState(this.state)
-		this.emit('stateChanged', this.state, command)
+		if (typeof command.applyToState === 'function') {
+			command.applyToState(this.state)
+			this.emit('stateChanged', this.state, command)
+		}
 	}
 
 	private _resolveCommand (packetId: number) {

--- a/src/commands/AbstractCommand.ts
+++ b/src/commands/AbstractCommand.ts
@@ -11,9 +11,9 @@ export default abstract class AbstractCommand {
 
 	abstract properties: any
 
-	abstract deserialize (rawCommand: Buffer): void
-	abstract serialize (): Buffer
-	abstract applyToState (state: AtemState): void
+	deserialize? (rawCommand: Buffer): void
+	serialize? (): Buffer
+	applyToState? (state: AtemState): void
 
 	updateProps (newProps: object) {
 		this._updateProps(newProps)

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -70,6 +70,10 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	public _sendCommand (command: AbstractCommand) {
+		if (typeof command.serialize !== 'function') {
+			return
+		}
+
 		const payload = command.serialize()
 		this.log(payload)
 		const buffer = new Buffer(16 + payload.length)
@@ -143,7 +147,7 @@ export class AtemSocket extends EventEmitter {
 
 		// this.log('COMMAND', `${name}(${length})`, buffer.slice(0, length))
 		const cmd = this._commandParser.commandFromRawName(name)
-		if (cmd) {
+		if (cmd && typeof cmd.deserialize === 'function') {
 			cmd.deserialize(buffer.slice(0, length).slice(8))
 			cmd.packetId = packetId || -1
 			this.emit('receivedStateChange', cmd)


### PR DESCRIPTION
As discussed on Slack, this makes it easier for us to add commands which don't necessarily use all of the AbstractCommand methods.