### PR TITLE
fix(atemSocket): fix _maxPacketID being off-by-one

### DIFF
--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -12,7 +12,7 @@ export class AtemSocket extends EventEmitter {
 	private _retransmitTimer: NodeJS.Timer | undefined
 
 	private _localPacketId = 1
-	private _maxPacketID = 1 << 15 // Atem expects 15 not 16 bits before wrapping
+	private _maxPacketID = (1 << 15) - 1 // Atem expects 15 not 16 bits before wrapping
 	private _sessionId: number
 
 	private _address: string


### PR DESCRIPTION
This would cause every 32768th packet to be dropped. This issue was most noticeable when transferring media to the ATEM.

This issue was jointly discovered by @Julusian, @baltedewit, and myself.