### PR TITLE
fix(socket): prevent connection from dying when the main thread is blocked

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/exit-hook": "^1.1.0",
     "@types/jest": "^22.1.3",
     "@types/node": "^8.0.4",
-    "@types/p-retry": "^1.0.1",
+    "@types/p-retry": "^2.0.0",
     "codecov": "^2.2.0",
     "cpx": "^1.5.0",
     "gh-pages": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@types/jest": "^22.1.3",
     "@types/node": "^8.0.4",
+    "@types/p-retry": "^1.0.1",
     "codecov": "^2.2.0",
     "cpx": "^1.5.0",
     "gh-pages": "^1.0.0",
@@ -103,6 +104,7 @@
     "video"
   ],
   "dependencies": {
+    "p-retry": "^2.0.0",
     "pngjs": "^3.3.2",
     "tslib": "^1.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "node": ">=4.5"
   },
   "devDependencies": {
+    "@types/exit-hook": "^1.1.0",
     "@types/jest": "^22.1.3",
     "@types/node": "^8.0.4",
     "@types/p-retry": "^1.0.1",
@@ -104,6 +105,7 @@
     "video"
   ],
   "dependencies": {
+    "exit-hook": "^2.0.0",
     "p-retry": "^2.0.0",
     "pngjs": "^3.3.2",
     "tslib": "^1.9.0"

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -63,7 +63,7 @@ export class Atem extends EventEmitter {
 	}
 
 	connect (address: string, port?: number) {
-		this.socket.connect(address, port)
+		return this.socket.connect(address, port)
 	}
 
 	disconnect (): Promise<void> {

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 import { AtemState } from './state'
 import { AtemSocket } from './lib/atemSocket'
-import { MacroAction } from './enums'
+import { IPCMessageType, MacroAction } from './enums'
 import AbstractCommand from './commands/AbstractCommand'
 import * as Commands from './commands'
 import { MediaPlayer } from './state/media'
@@ -56,7 +56,7 @@ export class Atem extends EventEmitter {
 			port: (options || {}).port
 		})
 		this.socket.on('receivedStateChange', (command: AbstractCommand) => this._mutateState(command))
-		this.socket.on('commandAcknowleged', (packetId: number) => this._resolveCommand(packetId))
+		this.socket.on(IPCMessageType.CommandAcknowledged, ({trackingId}: {trackingId: number}) => this._resolveCommand(trackingId))
 		this.socket.on('error', (e) => this.emit('error', e))
 		this.socket.on('connect', () => this.emit('connected'))
 		this.socket.on('disconnect', () => this.emit('disconnected'))
@@ -74,13 +74,12 @@ export class Atem extends EventEmitter {
 
 	sendCommand (command: AbstractCommand): Promise<any> {
 		const nextPacketId = this.socket.nextPacketId
-		const promise = new Promise((resolve, reject) => {
+		this._sentQueue[nextPacketId] = command
+		return new Promise((resolve, reject) => {
 			command.resolve = resolve
 			command.reject = reject
+			this.socket._sendCommand(command, nextPacketId).catch(reject)
 		})
-		this._sentQueue[nextPacketId] = command
-		this.socket._sendCommand(command)
-		return promise
 	}
 
 	changeProgramInput (input: number, me = 0) {
@@ -340,10 +339,10 @@ export class Atem extends EventEmitter {
 		}
 	}
 
-	private _resolveCommand (packetId: number) {
-		if (this._sentQueue[packetId]) {
-			this._sentQueue[packetId].resolve(this._sentQueue[packetId])
-			delete this._sentQueue[packetId]
+	private _resolveCommand (trackingId: number) {
+		if (this._sentQueue[trackingId]) {
+			this._sentQueue[trackingId].resolve(this._sentQueue[trackingId])
+			delete this._sentQueue[trackingId]
 		}
 	}
 }

--- a/src/enums/index.ts
+++ b/src/enums/index.ts
@@ -185,3 +185,12 @@ export enum SuperSourceArtOption {
 	Background,
 	Foreground
 }
+
+export enum IPCMessageType {
+	Log = 'log',
+	Connect = 'connect',
+	Disconnect = 'disconnect',
+	InboundCommand = 'inboundCommand',
+	OutboundCommand = 'outboundCommand',
+	CommandAcknowledged = 'commandAcknowledged'
+}

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -95,7 +95,7 @@ export class AtemSocket extends EventEmitter {
 			this._socketProcess = null
 		}
 
-		this._socketProcess = fork(path.resolve(__dirname, 'atemSocketChild.js'), [], {silent: true})
+		this._socketProcess = fork(path.resolve(__dirname, '../socket-child.js'), [], {silent: true})
 		this._socketProcess.on('message', this._receiveSubprocessMessage.bind(this))
 		this._socketProcess.on('error', error => {
 			this.emit('error', error)
@@ -123,7 +123,7 @@ export class AtemSocket extends EventEmitter {
 			throw new Error('Socket process process does not exist')
 		}
 
-		return Util.sendIPCMessage(this, '_socketProcess', message)
+		return Util.sendIPCMessage(this, '_socketProcess', message, this.log)
 	}
 
 	private _receiveSubprocessMessage (message: any) {

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -111,7 +111,7 @@ export class AtemSocket extends EventEmitter {
 			this._socketProcess = null
 		}
 
-		this._socketProcess = fork(path.resolve('dist/lib/atemSocketChild.js'), [], {silent: true})
+		this._socketProcess = fork(path.resolve(__dirname, 'atemSocketChild.js'), [], {silent: true})
 		this._socketProcess.on('message', this._receiveMessage.bind(this))
 		this._socketProcess.on('error', error => {
 			this.emit('error', error)

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -5,6 +5,7 @@ import { CommandParser } from './atemCommandParser'
 import AbstractCommand from '../commands/AbstractCommand'
 import { IPCMessageType } from '../enums'
 import * as pRetry from 'p-retry'
+import exitHook = require('exit-hook')
 
 export class AtemSocket extends EventEmitter {
 	private _debug = false
@@ -27,7 +28,7 @@ export class AtemSocket extends EventEmitter {
 		// When the parent process begins exiting, remove the listeners on our child process.
 		// We do this to avoid throwing an error when the child process exits
 		// as a natural part of the parent process exiting.
-		process.on('exit', () => {
+		exitHook(() => {
 			if (this._socketProcess) {
 				this._socketProcess.removeAllListeners()
 			}

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -1,30 +1,15 @@
-import { createSocket, Socket } from 'dgram'
+import { ChildProcess, fork } from 'child_process'
 import { EventEmitter } from 'events'
-import { Util } from './atemUtil'
+import * as path from 'path'
 import { CommandParser } from './atemCommandParser'
-import { ConnectionState, PacketFlag } from '../enums'
 import AbstractCommand from '../commands/AbstractCommand'
 
 export class AtemSocket extends EventEmitter {
-	private _connectionState = ConnectionState.Closed
 	private _debug = false
-	private _reconnectTimer: NodeJS.Timer | undefined
-	private _retransmitTimer: NodeJS.Timer | undefined
-
 	private _localPacketId = 1
-	private _maxPacketID = (1 << 15) - 1 // Atem expects 15 not 16 bits before wrapping
-	private _sessionId: number
-
 	private _address: string
 	private _port: number = 9910
-	private _socket: Socket
-	private _reconnectInterval = 5000
-
-	private _inFlightTimeout = 200
-	private _maxRetries = 5
-	private _lastReceivedAt: number = Date.now()
-	private _inFlight: Array<{packetId: number, lastSent: number, packet: Buffer, resent: number}> = []
-
+	private _socketProcess: ChildProcess
 	private _commandParser: CommandParser = new CommandParser()
 
 	constructor (options: { address?: string, port?: number, debug?: boolean, log?: (args1: any, args2?: any, args3?: any) => void }) {
@@ -34,30 +19,10 @@ export class AtemSocket extends EventEmitter {
 		this._debug = options.debug || false
 		this.log = options.log || this.log
 
-		this._createSocket()
+		this._createSocketProcess()
 	}
 
 	public connect (address?: string, port?: number) {
-		if (!this._reconnectTimer) {
-			this._reconnectTimer = setInterval(() => {
-				if (this._lastReceivedAt + this._reconnectInterval > Date.now()) return
-				if (this._connectionState === ConnectionState.Established) {
-					this._connectionState = ConnectionState.Closed
-					this.emit('disconnect', null, null)
-				}
-				this._localPacketId = 1
-				this._sessionId = 0
-				this.log('reconnect')
-				if (this._address && this._port) {
-					this._sendPacket(Util.COMMAND_CONNECT_HELLO)
-					this._connectionState = ConnectionState.SynSent
-				}
-			}, this._reconnectInterval)
-		}
-		if (!this._retransmitTimer) {
-			this._retransmitTimer = setInterval(() => this._checkForRetransmit(), 50)
-		}
-
 		if (address) {
 			this._address = address
 		}
@@ -65,28 +30,27 @@ export class AtemSocket extends EventEmitter {
 			this._port = port
 		}
 
-		this._sendPacket(Util.COMMAND_CONNECT_HELLO)
-		this._connectionState = ConnectionState.SynSent
+		return this._socketProcess.send({
+			cmd: 'connect',
+			payload: {
+				address,
+				port
+			}
+		})
 	}
 
 	public disconnect () {
-		return new Promise((resolve) => {
-			if (this._connectionState === ConnectionState.Established) {
-				this._socket.close(() => {
-					clearInterval(this._retransmitTimer as NodeJS.Timer)
-					clearInterval(this._reconnectTimer as NodeJS.Timer)
-					this._retransmitTimer = undefined
-					this._reconnectTimer = undefined
-
-					this._connectionState = ConnectionState.Closed
-					this._createSocket()
-					this.emit('disconnect')
-
+		return new Promise((resolve, reject) => {
+			// @ts-ignore
+			this._socketProcess.send({
+				cmd: 'disconnect'
+			}, (error: Error) => {
+				if (error) {
+					reject(error)
+				} else {
 					resolve()
-				})
-			} else {
-				resolve()
-			}
+				}
+			})
 		})
 	}
 
@@ -105,74 +69,31 @@ export class AtemSocket extends EventEmitter {
 
 		const payload = command.serialize()
 		if (this._debug) this.log('PAYLOAD', payload)
-		const buffer = new Buffer(16 + payload.length)
-		buffer.fill(0)
-
-		buffer[0] = (16 + payload.length) / 256 | 0x08
-		buffer[1] = (16 + payload.length) % 256
-		buffer[2] = this._sessionId >> 8
-		buffer[3] = this._sessionId & 0xff
-		buffer[10] = this._localPacketId / 256
-		buffer[11] = this._localPacketId % 256
-		buffer[12] = (4 + payload.length) / 256
-		buffer[13] = (4 + payload.length) % 256
-
-		payload.copy(buffer, 16)
-		this._sendPacket(buffer)
-
-		this._inFlight.push({ packetId: this._localPacketId, lastSent: Date.now(), packet: buffer, resent: 0 })
-		this._localPacketId++
-		if (this._maxPacketID < this._localPacketId) this._localPacketId = 0
+		return this._socketProcess.send({
+			cmd: 'sendCommand',
+			payload
+		})
 	}
 
-	private _createSocket () {
-		this._socket = createSocket('udp4')
-		this._socket.bind(1024 + Math.floor(Math.random() * 64511))
-		this._socket.on('message', (packet, rinfo) => this._receivePacket(packet, rinfo))
-		this._socket.on('close', () => this.emit('disconnect'))
+	private _createSocketProcess () {
+		this._socketProcess = fork(path.resolve('dist/lib/atemSocketChild.js'))
+		this._socketProcess.on('message', this._receiveMessage.bind(this))
 	}
 
-	private _receivePacket (packet: Buffer, rinfo: any) {
-		if (this._debug) this.log('RECV ', packet)
-		this._lastReceivedAt = Date.now()
-		const length = ((packet[0] & 0x07) << 8) | packet[1]
-		if (length !== rinfo.size) return
-
-		const flags = packet[0] >> 3
-		// this._sessionId = [packet[2], packet[3]]
-		this._sessionId = packet[2] << 8 | packet[3]
-		const remotePacketId = packet[10] << 8 | packet[11]
-
-		// Send hello answer packet when receive connect flags
-		if (flags & PacketFlag.Connect && !(flags & PacketFlag.Repeat)) {
-			this._sendPacket(Util.COMMAND_CONNECT_HELLO_ANSWER)
+	private _receiveMessage (message: any) {
+		if (typeof message !== 'object') {
+			return
 		}
 
-		// Parse commands, Emit 'stateChanged' event after parse
-		if (flags & PacketFlag.AckRequest && length > 12) {
-			this._parseCommand(packet.slice(12), remotePacketId)
+		if (typeof message.cmd !== 'string' || message.cmd.length <= 0) {
+			return
 		}
 
-		// Send ping packet, Emit 'connect' event after receive all stats
-		if (flags & PacketFlag.AckRequest && length === 12 && this._connectionState === ConnectionState.SynSent) {
-			this._connectionState = ConnectionState.Established
-		}
-
-		// Send ack packet (called by answer packet in Skaarhoj)
-		if (flags & PacketFlag.AckRequest && this._connectionState === ConnectionState.Established) {
-			this._sendAck(remotePacketId)
-			this.emit('ping')
-		}
-
-		// Device ack'ed our command
-		if (flags & PacketFlag.AckReply && this._connectionState === ConnectionState.Established) {
-			const ackPacketId = packet[4] << 8 | packet[5]
-			for (const i in this._inFlight) {
-				if (ackPacketId >= this._inFlight[i].packetId) {
-					this.emit('commandAcknowleged', this._inFlight[i].packetId)
-					delete this._inFlight[i]
-				}
-			}
+		const payload = message.payload
+		switch (message.cmd) {
+			case 'commandPacket':
+				this._parseCommand(Buffer.from(payload.packet.data), payload.remotePacketId)
+				break
 		}
 	}
 
@@ -200,40 +121,4 @@ export class AtemSocket extends EventEmitter {
 			this._parseCommand(buffer.slice(length), packetId)
 		}
 	}
-
-	private _sendPacket (packet: Buffer) {
-		if (this._debug) this.log('SEND ', packet)
-		this._socket.send(packet, 0, packet.length, this._port, this._address)
-	}
-
-	private _sendAck (packetId: number) {
-		const buffer = new Buffer(12)
-		buffer.fill(0)
-		buffer[0] = 0x80
-		buffer[1] = 0x0C
-		buffer[2] = this._sessionId >> 8
-		buffer[3] = this._sessionId & 0xFF
-		buffer[4] = packetId >> 8
-		buffer[5] = packetId & 0xFF
-		buffer[9] = 0x41
-		this._sendPacket(buffer)
-	}
-
-	private _checkForRetransmit () {
-		for (const sentPacket of this._inFlight) {
-			if (sentPacket && sentPacket.lastSent + this._inFlightTimeout < Date.now()) {
-				if (sentPacket.resent <= this._maxRetries) {
-					sentPacket.lastSent = Date.now()
-					sentPacket.resent++
-					this.log('RESEND: ', sentPacket)
-					this._sendPacket(sentPacket.packet)
-				} else {
-					this._inFlight.splice(this._inFlight.indexOf(sentPacket), 1)
-					this.log('TIMED OUT: ', sentPacket.packet)
-					// @todo: we should probably break up the connection here.
-				}
-			}
-		}
-	}
-
 }

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -132,21 +132,23 @@ export class AtemSocket extends EventEmitter {
 				// unsent messages exceeds a threshold that makes it unwise to send more.
 				// Otherwise, the method returns true."
 				const sendResult = this._socketProcess.send(message, (error: Error) => {
-					if (error && !handled) {
+					if (handled) {
+						return
+					}
+
+					if (error) {
 						handled = true
 						reject(error)
+					} else {
+						resolve()
 					}
+
+					handled = true
 				})
 
-				if (handled) {
-					return
-				}
-
-				handled = true
-				if (sendResult) {
-					resolve()
-				} else {
+				if (!sendResult && !handled) {
 					reject(new Error('Failed to send message to socket process'))
+					handled = true
 				}
 			})
 		}, {

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'events'
 import * as path from 'path'
 import { CommandParser } from './atemCommandParser'
 import AbstractCommand from '../commands/AbstractCommand'
+import { Util } from './atemUtil'
 
 export class AtemSocket extends EventEmitter {
 	private _debug = false
@@ -39,44 +40,20 @@ export class AtemSocket extends EventEmitter {
 			this._port = port
 		}
 
-		return new Promise((resolve, reject) => {
-			if (!this._socketProcess) {
-				return resolve()
+		return Util.subprocessSendPromise(this._socketProcess, {
+			cmd: 'connect',
+			payload: {
+				address: this._address,
+				port: this._port
 			}
-
-			this._socketProcess.send({
-				cmd: 'connect',
-				payload: {
-					address: this._address,
-					port: this._port
-				}
-			}, (error: Error) => {
-				if (error) {
-					reject(error)
-				} else {
-					resolve()
-				}
-			})
 		})
 	}
 
 	public disconnect () {
 		this._shouldConnect = false
 
-		return new Promise((resolve, reject) => {
-			if (!this._socketProcess) {
-				return resolve()
-			}
-
-			this._socketProcess.send({
-				cmd: 'disconnect'
-			}, (error: Error) => {
-				if (error) {
-					reject(error)
-				} else {
-					resolve()
-				}
-			})
+		return Util.subprocessSendPromise(this._socketProcess, {
+			cmd: 'disconnect'
 		})
 	}
 

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -146,6 +146,9 @@ export class AtemSocket extends EventEmitter {
 			case IPCMessageType.InboundCommand:
 				this._parseCommand(Buffer.from(payload.packet.data), payload.remotePacketId)
 				break
+			case IPCMessageType.Disconnect:
+				this.emit(IPCMessageType.Disconnect)
+				break
 		}
 	}
 

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -67,6 +67,9 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	get nextPacketId (): number {
+		if (this._localPacketId >= Number.MAX_SAFE_INTEGER) {
+			this._localPacketId = 0
+		}
 		return ++this._localPacketId
 	}
 

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -21,6 +21,12 @@ export class AtemSocket extends EventEmitter {
 		this.log = options.log || this.log
 
 		this._createSocketProcess()
+
+		process.on('exit', () => {
+			if (this._socketProcess) {
+				this._socketProcess.removeAllListeners()
+			}
+		})
 	}
 
 	public connect (address?: string, port?: number) {

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -118,9 +118,9 @@ export class AtemSocket extends EventEmitter {
 			this.log('socket process error:', error)
 		})
 		this._socketProcess.on('exit', (code, signal) => {
-			this.emit('error', new Error(`The socket process unexpectedly closed (code: "${code}", signal: "${signal}")`))
-			this.log('socket process exit:', code, signal)
 			process.nextTick(() => {
+				this.emit('error', new Error(`The socket process unexpectedly closed (code: "${code}", signal: "${signal}")`))
+				this.log('socket process exit:', code, signal)
 				this._createSocketProcess()
 			})
 		})

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -76,7 +76,7 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	private _createSocketProcess () {
-		this._socketProcess = fork(path.resolve('dist/lib/atemSocketChild.js'))
+		this._socketProcess = fork(path.resolve('dist/lib/atemSocketChild.js'), [], {silent: true})
 		this._socketProcess.on('message', this._receiveMessage.bind(this))
 	}
 
@@ -91,6 +91,9 @@ export class AtemSocket extends EventEmitter {
 
 		const payload = message.payload
 		switch (message.cmd) {
+			case 'log':
+				this.log(message.payload)
+				break
 			case 'commandPacket':
 				this._parseCommand(Buffer.from(payload.packet.data), payload.remotePacketId)
 				break

--- a/src/lib/atemSocket.ts
+++ b/src/lib/atemSocket.ts
@@ -123,7 +123,7 @@ export class AtemSocket extends EventEmitter {
 			throw new Error('Socket process process does not exist')
 		}
 
-		return Util.sendIPCMessage(this._socketProcess, message, this.log)
+		return Util.sendIPCMessage(this, '_socketProcess', message)
 	}
 
 	private _receiveSubprocessMessage (message: any) {

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -1,5 +1,6 @@
 import { createSocket, Socket } from 'dgram'
 import { EventEmitter } from 'events'
+import { format } from 'util'
 import { Util } from './atemUtil'
 import { ConnectionState, PacketFlag } from '../enums'
 
@@ -85,7 +86,12 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	public log (...args: any[]): void {
-		console.log(...args)
+		// @ts-ignore
+		const payload = format(...args)
+		return (process as any).send({
+			cmd: 'log',
+			payload
+		})
 	}
 
 	get nextPacketId (): number {

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -1,0 +1,232 @@
+import { createSocket, Socket } from 'dgram'
+import { EventEmitter } from 'events'
+import { Util } from './atemUtil'
+import { ConnectionState, PacketFlag } from '../enums'
+
+export class AtemSocket extends EventEmitter {
+	private _connectionState = ConnectionState.Closed
+	private _debug = false
+	private _reconnectTimer: NodeJS.Timer | undefined
+	private _retransmitTimer: NodeJS.Timer | undefined
+
+	private _localPacketId = 1
+	private _maxPacketID = (1 << 15) - 1 // Atem expects 15 not 16 bits before wrapping
+	private _sessionId: number
+
+	private _address: string
+	private _port: number = 9910
+	private _socket: Socket
+	private _reconnectInterval = 5000
+
+	private _inFlightTimeout = 200
+	private _maxRetries = 5
+	private _lastReceivedAt: number = Date.now()
+	private _inFlight: Array<{packetId: number, lastSent: number, packet: Buffer, resent: number}> = []
+
+	constructor (options: { address?: string, port?: number } = {}) {
+		super()
+		this._address = options.address || this._address
+		this._port = options.port || this._port
+
+		this._createSocket()
+	}
+
+	public connect (address?: string, port?: number) {
+		if (!this._reconnectTimer) {
+			this._reconnectTimer = setInterval(() => {
+				if (this._lastReceivedAt + this._reconnectInterval > Date.now()) return
+				if (this._connectionState === ConnectionState.Established) {
+					this._connectionState = ConnectionState.Closed
+					this.emit('disconnect', null, null)
+				}
+				this._localPacketId = 1
+				this._sessionId = 0
+				this.log('reconnect')
+				if (this._address && this._port) {
+					this._sendPacket(Util.COMMAND_CONNECT_HELLO)
+					this._connectionState = ConnectionState.SynSent
+				}
+			}, this._reconnectInterval)
+		}
+		if (!this._retransmitTimer) {
+			this._retransmitTimer = setInterval(() => this._checkForRetransmit(), 50)
+		}
+
+		if (address) {
+			this._address = address
+		}
+		if (port) {
+			this._port = port
+		}
+
+		this._sendPacket(Util.COMMAND_CONNECT_HELLO)
+		this._connectionState = ConnectionState.SynSent
+	}
+
+	public disconnect () {
+		return new Promise((resolve) => {
+			if (this._connectionState === ConnectionState.Established) {
+				this._socket.close(() => {
+					clearInterval(this._retransmitTimer as NodeJS.Timer)
+					clearInterval(this._reconnectTimer as NodeJS.Timer)
+					this._retransmitTimer = undefined
+					this._reconnectTimer = undefined
+
+					this._connectionState = ConnectionState.Closed
+					this._createSocket()
+					this.emit('disconnect')
+
+					resolve()
+				})
+			} else {
+				resolve()
+			}
+		})
+	}
+
+	public log (...args: any[]): void {
+		console.log(...args)
+	}
+
+	get nextPacketId (): number {
+		return this._localPacketId
+	}
+
+	public _sendCommand (serializedCommand: Buffer) {
+		const payload = serializedCommand
+		if (this._debug) this.log('PAYLOAD', payload)
+		const buffer = new Buffer(16 + payload.length)
+		buffer.fill(0)
+
+		buffer[0] = (16 + payload.length) / 256 | 0x08
+		buffer[1] = (16 + payload.length) % 256
+		buffer[2] = this._sessionId >> 8
+		buffer[3] = this._sessionId & 0xff
+		buffer[10] = this._localPacketId / 256
+		buffer[11] = this._localPacketId % 256
+		buffer[12] = (4 + payload.length) / 256
+		buffer[13] = (4 + payload.length) % 256
+
+		payload.copy(buffer, 16)
+		this._sendPacket(buffer)
+
+		this._inFlight.push({ packetId: this._localPacketId, lastSent: Date.now(), packet: buffer, resent: 0 })
+		this._localPacketId++
+		if (this._maxPacketID < this._localPacketId) this._localPacketId = 0
+	}
+
+	private _createSocket () {
+		this._socket = createSocket('udp4')
+		this._socket.bind(1024 + Math.floor(Math.random() * 64511))
+		this._socket.on('message', (packet, rinfo) => this._receivePacket(packet, rinfo))
+	}
+
+	private _receivePacket (packet: Buffer, rinfo: any) {
+		if (this._debug) this.log('RECV ', packet)
+		this._lastReceivedAt = Date.now()
+		const length = ((packet[0] & 0x07) << 8) | packet[1]
+		if (length !== rinfo.size) return
+
+		const flags = packet[0] >> 3
+		// this._sessionId = [packet[2], packet[3]]
+		this._sessionId = packet[2] << 8 | packet[3]
+		const remotePacketId = packet[10] << 8 | packet[11]
+
+		// Send hello answer packet when receive connect flags
+		if (flags & PacketFlag.Connect && !(flags & PacketFlag.Repeat)) {
+			this._sendPacket(Util.COMMAND_CONNECT_HELLO_ANSWER)
+		}
+
+		// Parse commands, Emit 'stateChanged' event after parse
+		if (flags & PacketFlag.AckRequest && length > 12) {
+			(process as any).send({
+				cmd: 'commandPacket',
+				payload: {
+					packet: packet.slice(12),
+					remotePacketId
+				}
+			})
+		}
+
+		// Send ping packet, Emit 'connect' event after receive all stats
+		if (flags & PacketFlag.AckRequest && length === 12 && this._connectionState === ConnectionState.SynSent) {
+			this._connectionState = ConnectionState.Established
+		}
+
+		// Send ack packet (called by answer packet in Skaarhoj)
+		if (flags & PacketFlag.AckRequest && this._connectionState === ConnectionState.Established) {
+			this._sendAck(remotePacketId)
+			this.emit('ping')
+		}
+
+		// Device ack'ed our command
+		if (flags & PacketFlag.AckReply && this._connectionState === ConnectionState.Established) {
+			const ackPacketId = packet[4] << 8 | packet[5]
+			for (const i in this._inFlight) {
+				if (ackPacketId >= this._inFlight[i].packetId) {
+					this.emit('commandAcknowleged', this._inFlight[i].packetId)
+					delete this._inFlight[i]
+				}
+			}
+		}
+	}
+
+	private _sendPacket (packet: Buffer) {
+		if (this._debug) this.log('SEND ', packet)
+		this._socket.send(packet, 0, packet.length, this._port, this._address)
+	}
+
+	private _sendAck (packetId: number) {
+		const buffer = new Buffer(12)
+		buffer.fill(0)
+		buffer[0] = 0x80
+		buffer[1] = 0x0C
+		buffer[2] = this._sessionId >> 8
+		buffer[3] = this._sessionId & 0xFF
+		buffer[4] = packetId >> 8
+		buffer[5] = packetId & 0xFF
+		buffer[9] = 0x41
+		this._sendPacket(buffer)
+	}
+
+	private _checkForRetransmit () {
+		for (const sentPacket of this._inFlight) {
+			if (sentPacket && sentPacket.lastSent + this._inFlightTimeout < Date.now()) {
+				if (sentPacket.resent <= this._maxRetries) {
+					sentPacket.lastSent = Date.now()
+					sentPacket.resent++
+					this.log('RESEND: ', sentPacket)
+					this._sendPacket(sentPacket.packet)
+				} else {
+					this._inFlight.splice(this._inFlight.indexOf(sentPacket), 1)
+					this.log('TIMED OUT: ', sentPacket.packet)
+					// @todo: we should probably break up the connection here.
+				}
+			}
+		}
+	}
+}
+
+const singleton = new AtemSocket()
+process.on('message', message => {
+	if (typeof message !== 'object') {
+		return
+	}
+
+	if (typeof message.cmd !== 'string' || message.cmd.length <= 0) {
+		return
+	}
+
+	const payload = message.payload
+	switch (message.cmd) {
+		case 'connect':
+			singleton.connect(payload.address, payload.port)
+			break
+		case 'disconnect':
+			singleton.disconnect().catch(() => { /* discard error */ })
+			break
+		case 'sendCommand':
+			singleton._sendCommand(Buffer.from(payload.data))
+			break
+	}
+})

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -30,6 +30,12 @@ export class AtemSocketChild extends EventEmitter {
 		this._address = options.address || this._address
 		this._port = options.port || this._port
 
+		this.on('disconnect', () => {
+			this._sendParentMessage({
+				cmd: IPCMessageType.Disconnect
+			})
+		})
+
 		this._createSocket()
 	}
 

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -86,7 +86,7 @@ export class AtemSocketChild extends EventEmitter {
 
 	public log (...args: any[]): void {
 		const payload = format.apply(format, args)
-		this.emit('log', payload)
+		this.emit(IPCMessageType.Log, payload)
 	}
 
 	get nextPacketId (): number {

--- a/src/lib/atemSocketChild.ts
+++ b/src/lib/atemSocketChild.ts
@@ -86,8 +86,7 @@ export class AtemSocket extends EventEmitter {
 	}
 
 	public log (...args: any[]): void {
-		// @ts-ignore
-		const payload = format(...args)
+		const payload = format.apply(format, args)
 		return (process as any).send({
 			cmd: 'log',
 			payload

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -1,6 +1,4 @@
 import { IPCMessageType } from '../enums'
-import { AtemSocketChild } from './atemSocketChild'
-import { AtemSocket } from './atemSocket'
 import * as pRetry from 'p-retry'
 
 export namespace Util {
@@ -30,14 +28,15 @@ export namespace Util {
 	}
 
 	export function sendIPCMessage (
-		scope: AtemSocket | AtemSocketChild,
+		scope: any,
 		processProperty: string,
-		message: {cmd: IPCMessageType; payload?: any, _messageId?: number}
+		message: {cmd: IPCMessageType; payload?: any, _messageId?: number},
+		log: Function
 	) {
 		return pRetry(() => {
 			return new Promise((resolve, reject) => {
 				// This ensures that we will always grab the currently in-use process, if it has been re-made.
-				const destProcess = (scope as any)[processProperty]
+				const destProcess = scope[processProperty]
 				if (!destProcess || typeof destProcess.send !== 'function') {
 					return reject(new Error('Destination process has gone away'))
 				}
@@ -70,8 +69,8 @@ export namespace Util {
 			})
 		}, {
 			onFailedAttempt: error => {
-				if (scope.log) {
-					scope.log(`Failed to send IPC message (attempt ${error.attemptNumber}/${error.attemptNumber + error.attemptsLeft}).`)
+				if (log) {
+					log(`Failed to send IPC message (attempt ${error.attemptNumber}/${error.attemptNumber + error.attemptsLeft}).`)
 				}
 			},
 			retries: 5

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -1,3 +1,7 @@
+import { ChildProcess } from 'child_process'
+import { IPCMessageType } from '../enums'
+import * as pRetry from 'p-retry'
+
 export namespace Util {
 	export function stringToBytes (str: string): Array<number> {
 		const array = []
@@ -22,6 +26,53 @@ export namespace Util {
 	export function parseEnum<G> (value: G, type: any): G {
 		if (!type[value]) throw Error('Value is not a valid option in enum')
 		return value
+	}
+
+	export async function sendIPCMessage (
+		destProcess: NodeJS.Process | ChildProcess,
+		message: {cmd: IPCMessageType; payload?: any, _messageId?: number},
+		log?: (..._args: any[]) => void
+	) {
+		await pRetry(() => {
+			return new Promise((resolve, reject) => {
+				if (!destProcess || typeof destProcess.send !== 'function') {
+					return reject(new Error('Destination process has gone away'))
+				}
+
+				let handled = false
+
+				// From https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback:
+				// "subprocess.send() will return false if the channel has closed or when the backlog of
+				// unsent messages exceeds a threshold that makes it unwise to send more.
+				// Otherwise, the method returns true."
+				const sendResult = destProcess.send(message, (error: Error) => {
+					if (handled) {
+						return
+					}
+
+					if (error) {
+						handled = true
+						reject(error)
+					} else {
+						resolve()
+					}
+
+					handled = true
+				})
+
+				if (!sendResult && !handled) {
+					reject(new Error('Failed to send message to socket process'))
+					handled = true
+				}
+			})
+		}, {
+			onFailedAttempt: error => {
+				if (log) {
+					log(`Failed to send message to socket process (attempt ${error.attemptNumber}/${error.attemptNumber + error.attemptsLeft}).`)
+				}
+			},
+			retries: 5
+		})
 	}
 
 	export const COMMAND_CONNECT_HELLO = Buffer.from([

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -1,5 +1,3 @@
-import { ChildProcess } from 'child_process'
-
 export namespace Util {
 	export function stringToBytes (str: string): Array<number> {
 		const array = []
@@ -24,22 +22,6 @@ export namespace Util {
 	export function parseEnum<G> (value: G, type: any): G {
 		if (!type[value]) throw Error('Value is not a valid option in enum')
 		return value
-	}
-
-	export function subprocessSendPromise (subprocess: ChildProcess | null, message: any) {
-		return new Promise((resolve, reject) => {
-			if (!subprocess) {
-				return resolve()
-			}
-
-			subprocess.send(message, (error: Error) => {
-				if (error) {
-					reject(error)
-				} else {
-					resolve()
-				}
-			})
-		})
 	}
 
 	export const COMMAND_CONNECT_HELLO = Buffer.from([

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -29,12 +29,12 @@ export namespace Util {
 		return value
 	}
 
-	export async function sendIPCMessage (
+	export function sendIPCMessage (
 		scope: AtemSocket | AtemSocketChild,
 		processProperty: string,
 		message: {cmd: IPCMessageType; payload?: any, _messageId?: number}
 	) {
-		await pRetry(() => {
+		return pRetry(() => {
 			return new Promise((resolve, reject) => {
 				// This ensures that we will always grab the currently in-use process, if it has been re-made.
 				const destProcess = (scope as any)[processProperty]

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -64,14 +64,14 @@ export namespace Util {
 				})
 
 				if (!sendResult && !handled) {
-					reject(new Error('Failed to send message to socket process'))
+					reject(new Error('Failed to send IPC message'))
 					handled = true
 				}
 			})
 		}, {
 			onFailedAttempt: error => {
 				if (scope.log) {
-					scope.log(`Failed to send message to socket process (attempt ${error.attemptNumber}/${error.attemptNumber + error.attemptsLeft}).`)
+					scope.log(`Failed to send IPC message (attempt ${error.attemptNumber}/${error.attemptNumber + error.attemptsLeft}).`)
 				}
 			},
 			retries: 5

--- a/src/lib/atemUtil.ts
+++ b/src/lib/atemUtil.ts
@@ -1,3 +1,5 @@
+import { ChildProcess } from 'child_process'
+
 export namespace Util {
 	export function stringToBytes (str: string): Array<number> {
 		const array = []
@@ -22,6 +24,22 @@ export namespace Util {
 	export function parseEnum<G> (value: G, type: any): G {
 		if (!type[value]) throw Error('Value is not a valid option in enum')
 		return value
+	}
+
+	export function subprocessSendPromise (subprocess: ChildProcess | null, message: any) {
+		return new Promise((resolve, reject) => {
+			if (!subprocess) {
+				return resolve()
+			}
+
+			subprocess.send(message, (error: Error) => {
+				if (error) {
+					reject(error)
+				} else {
+					resolve()
+				}
+			})
+		})
 	}
 
 	export const COMMAND_CONNECT_HELLO = Buffer.from([

--- a/src/socket-child.ts
+++ b/src/socket-child.ts
@@ -29,14 +29,14 @@ process.on('message', message => {
 singleton.on(IPCMessageType.Disconnect, () => {
 	sendParentMessage({
 		cmd: IPCMessageType.Disconnect
-	}).catch(() => { /* Discard errors. */ })
+	})
 })
 
 singleton.on('log', (message: string) => {
 	sendParentMessage({
 		cmd: IPCMessageType.Log,
 		payload: message
-	}).catch(() => { /* Discard errors. */ })
+	})
 })
 
 singleton.on(IPCMessageType.InboundCommand, (packet: Buffer, remotePacketId: number) => {
@@ -46,7 +46,7 @@ singleton.on(IPCMessageType.InboundCommand, (packet: Buffer, remotePacketId: num
 			packet,
 			remotePacketId
 		}
-	}).catch(() => { /* Discard errors. */ })
+	})
 })
 
 singleton.on(IPCMessageType.CommandAcknowledged, (commandId: number, trackingId: number) => {
@@ -56,9 +56,9 @@ singleton.on(IPCMessageType.CommandAcknowledged, (commandId: number, trackingId:
 			commandId,
 			trackingId
 		}
-	}).catch(() => { /* Discard errors. */ })
+	})
 })
 
 function sendParentMessage (message: {cmd: IPCMessageType; payload?: any}) {
-	return Util.sendIPCMessage(global, 'process', message, singleton.log)
+	Util.sendIPCMessage(global, 'process', message, singleton.log).catch(() => { /* Discard errors. */ })
 }

--- a/src/socket-child.ts
+++ b/src/socket-child.ts
@@ -1,0 +1,64 @@
+import { IPCMessageType } from './enums'
+import { Util } from './lib/atemUtil'
+import { AtemSocketChild } from './lib/atemSocketChild'
+
+const singleton = new AtemSocketChild()
+process.on('message', message => {
+	if (typeof message !== 'object') {
+		return
+	}
+
+	if (typeof message.cmd !== 'string' || message.cmd.length <= 0) {
+		return
+	}
+
+	const payload = message.payload
+	switch (message.cmd) {
+		case IPCMessageType.Connect:
+			singleton.connect(payload.address, payload.port)
+			break
+		case IPCMessageType.Disconnect:
+			singleton.disconnect().catch(() => { /* discard error */ })
+			break
+		case IPCMessageType.OutboundCommand:
+			singleton._sendCommand(Buffer.from(payload.data.data), payload.trackingId)
+			break
+	}
+})
+
+singleton.on(IPCMessageType.Disconnect, () => {
+	sendParentMessage({
+		cmd: IPCMessageType.Disconnect
+	}).catch(() => { /* Discard errors. */ })
+})
+
+singleton.on('log', (message: string) => {
+	sendParentMessage({
+		cmd: IPCMessageType.Log,
+		payload: message
+	}).catch(() => { /* Discard errors. */ })
+})
+
+singleton.on(IPCMessageType.InboundCommand, (packet: Buffer, remotePacketId: number) => {
+	sendParentMessage({
+		cmd: IPCMessageType.InboundCommand,
+		payload: {
+			packet,
+			remotePacketId
+		}
+	}).catch(() => { /* Discard errors. */ })
+})
+
+singleton.on(IPCMessageType.CommandAcknowledged, (commandId: number, trackingId: number) => {
+	sendParentMessage({
+		cmd: IPCMessageType.CommandAcknowledged,
+		payload: {
+			commandId,
+			trackingId
+		}
+	}).catch(() => { /* Discard errors. */ })
+})
+
+function sendParentMessage (message: {cmd: IPCMessageType; payload?: any}) {
+	return Util.sendIPCMessage(global, 'process', message, singleton.log)
+}

--- a/src/socket-child.ts
+++ b/src/socket-child.ts
@@ -32,7 +32,7 @@ singleton.on(IPCMessageType.Disconnect, () => {
 	})
 })
 
-singleton.on('log', (message: string) => {
+singleton.on(IPCMessageType.Log, (message: string) => {
 	sendParentMessage({
 		cmd: IPCMessageType.Log,
 		payload: message

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,16 @@
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.4.tgz#d0ca03fa4a3d7ab66c1f4e78a0fd06e30e46a7a9"
 
+"@types/p-retry@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/p-retry/-/p-retry-1.0.1.tgz#2302bc3da425014208c8a9b68293d37325124785"
+  dependencies:
+    "@types/retry" "*"
+
+"@types/retry@*":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.10.2.tgz#bd1740c4ad51966609b058803ee6874577848b37"
+
 "@types/shelljs@^0.7.0":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.2.tgz#c2bdb3fe80cd7a3da08750ca898ae44c589671f3"
@@ -3303,6 +3313,12 @@ p-locate@^2.0.0:
   dependencies:
     p-limit "^1.1.0"
 
+p-retry@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-2.0.0.tgz#b97f1f4d6d81a3c065b2b40107b811e995c1bfba"
+  dependencies:
+    retry "^0.12.0"
+
 package-json@^2.0.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/package-json/-/package-json-2.4.0.tgz#0d15bd67d1cbbddbb2ca222ff2edb86bcb31a8bb"
@@ -3809,6 +3825,10 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
 
 right-align@^0.1.1:
   version "0.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -58,9 +58,9 @@
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.4.tgz#d0ca03fa4a3d7ab66c1f4e78a0fd06e30e46a7a9"
 
-"@types/p-retry@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/p-retry/-/p-retry-1.0.1.tgz#2302bc3da425014208c8a9b68293d37325124785"
+"@types/p-retry@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/p-retry/-/p-retry-2.0.0.tgz#8d5e3ef380dde8a0b46d254a68861c7ec6ca2d80"
   dependencies:
     "@types/retry" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,10 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/df/-/df-1.0.1.tgz#c69b66f52f6fcdd287c807df210305dbaf78500d"
 
+"@types/exit-hook@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/exit-hook/-/exit-hook-1.1.0.tgz#de9d0fdb8a333ef70109920b0f908db41ffe425d"
+
 "@types/fs-extra@^4.0.0":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.5.tgz#8aa6033c0e87c653b09a6711686916864b48ec9e"
@@ -1375,6 +1379,10 @@ execa@^0.5.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
+
+exit-hook@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-2.0.0.tgz#b89f6f69b7d080efc2807c66a85957722637db92"
 
 exit@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It moves the UDP socket so a child process.


* **What is the current behavior?** (You can also link to an open issue here)
Whenever the main thread is blocked, our socket is unable to send messages or process received messages. This is a problem, since the ATEM will close or re-initialize our connection if we fail to respond to pings for about a second.


* **What is the new behavior (if this is a feature change)?**
This PR moves the socket to a child process, so that the main thread can be blocked without our socket missing pings, therefore keeping our connection to the ATEM alive regardless of how hard the main thread is churning.