### PR TITLE
feat: implement MacroRunStatus command (MRPr)

### DIFF
--- a/src/commands/Macro/MacroRunStatusCommand.ts
+++ b/src/commands/Macro/MacroRunStatusCommand.ts
@@ -1,0 +1,27 @@
+import AbstractCommand from '../AbstractCommand'
+import { AtemState } from '../../state'
+
+export class MacroRunStatusCommand extends AbstractCommand {
+	rawName = 'MRPr'
+	index: number
+
+	properties: {
+		isRunning: boolean
+		isWaiting: boolean
+		loop: boolean
+	}
+
+	deserialize (rawCommand: Buffer) {
+		this.index = rawCommand.readUInt16BE(2)
+		this.properties = {
+			isRunning: Boolean(rawCommand[0] & 1 << 0),
+			isWaiting: Boolean(rawCommand[0] & 1 << 1),
+			loop: Boolean(rawCommand[1] & 1 << 0)
+		}
+	}
+
+	applyToState (state: AtemState) {
+		const macro = state.getMacro(this.index)
+		Object.assign(macro, this.properties)
+	}
+}

--- a/src/commands/Macro/MacroRunStatusCommand.ts
+++ b/src/commands/Macro/MacroRunStatusCommand.ts
@@ -3,25 +3,27 @@ import { AtemState } from '../../state'
 
 export class MacroRunStatusCommand extends AbstractCommand {
 	rawName = 'MRPr'
-	index: number
 
 	properties: {
 		isRunning: boolean
 		isWaiting: boolean
 		loop: boolean
+		macroIndex: number
 	}
 
 	deserialize (rawCommand: Buffer) {
-		this.index = rawCommand.readUInt16BE(2)
 		this.properties = {
 			isRunning: Boolean(rawCommand[0] & 1 << 0),
 			isWaiting: Boolean(rawCommand[0] & 1 << 1),
-			loop: Boolean(rawCommand[1] & 1 << 0)
+			loop: Boolean(rawCommand[1] & 1 << 0),
+			macroIndex: rawCommand.readUInt16BE(2)
 		}
 	}
 
 	applyToState (state: AtemState) {
-		const macro = state.getMacro(this.index)
-		Object.assign(macro, this.properties)
+		state.macroPlayer = {
+			...state.macroPlayer,
+			...this.properties
+		}
 	}
 }

--- a/src/commands/Macro/index.ts
+++ b/src/commands/Macro/index.ts
@@ -1,1 +1,2 @@
 export * from './MacroActionCommand'
+export * from './MacroRunStatusCommand'

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -3,6 +3,7 @@ import { AtemVideoState } from './video'
 import { AtemAudioState } from './audio'
 import { MediaState } from './media'
 import { InputChannel } from './input'
+import { MacroState } from './macro'
 
 export class AtemState {
 	info = new DeviceInfo()
@@ -15,4 +16,13 @@ export class AtemState {
 	audio: AtemAudioState = new AtemAudioState()
 	media: MediaState = new MediaState()
 	inputs: Array<InputChannel> = []
+	macros: Array<MacroState> = []
+
+	getMacro (index: number) {
+		if (!this.macros[index]) {
+			this.macros[index] = {} as MacroState
+		}
+
+		return this.macros[index]
+	}
 }

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -3,7 +3,7 @@ import { AtemVideoState } from './video'
 import { AtemAudioState } from './audio'
 import { MediaState } from './media'
 import { InputChannel } from './input'
-import { MacroState } from './macro'
+import { MacroPlayerState } from './macroPlayer'
 
 export class AtemState {
 	info = new DeviceInfo()
@@ -16,13 +16,5 @@ export class AtemState {
 	audio: AtemAudioState = new AtemAudioState()
 	media: MediaState = new MediaState()
 	inputs: Array<InputChannel> = []
-	macros: Array<MacroState> = []
-
-	getMacro (index: number) {
-		if (!this.macros[index]) {
-			this.macros[index] = {} as MacroState
-		}
-
-		return this.macros[index]
-	}
+	macroPlayer: MacroPlayerState
 }

--- a/src/state/macro.ts
+++ b/src/state/macro.ts
@@ -1,0 +1,5 @@
+export interface MacroState {
+	isRunning: boolean
+	isWaiting: boolean
+	loop: boolean
+}

--- a/src/state/macroPlayer.ts
+++ b/src/state/macroPlayer.ts
@@ -1,5 +1,6 @@
-export interface MacroState {
+export interface MacroPlayerState {
 	isRunning: boolean
 	isWaiting: boolean
 	loop: boolean
+	macroIndex: number
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It implements the MacroRunStatus command (`MRPr`).


* **What is the current behavior?** (You can also link to an open issue here)
This command is not yet implemented in the current release.


* **What is the new behavior (if this is a feature change)?**
The state of a given macro can now be tracked. Specifically, these pieces of state:
```ts
export interface MacroPlayerState {
	isRunning: boolean
	isWaiting: boolean
	loop: boolean
	index: number
}
```


* **Other information**:
The primary use of this command is for keeping track of when a macro has begun and/or finished its execution. Useful for writing external code which reacts to macros being invoked.
