### PR TITLE
fix: kill the child process with an error code with an uncaughtException or unhandledRejection occurs

### DIFF
--- a/src/socket-child.ts
+++ b/src/socket-child.ts
@@ -26,6 +26,20 @@ process.on('message', message => {
 	}
 })
 
+process.on('uncaughtException', error => {
+	console.error('uncaughtException:', error)
+	setTimeout(() => {
+		process.exit(1)
+	}, 10)
+})
+
+process.on('unhandledRejection', reason => {
+	console.error('unhandledRejection:', reason)
+	setTimeout(() => {
+		process.exit(1)
+	}, 10)
+})
+
 singleton.on(IPCMessageType.Disconnect, () => {
 	sendParentMessage({
 		cmd: IPCMessageType.Disconnect


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
If the socket child process encounters an error, it won't inform the parent process. See #40.


* **What is the new behavior (if this is a feature change)?**
Kill the child process with a `1` error code as soon as one of these unhandled exceptions occurs.


* **Other information**:
Helps #40.