### PR TITLE
fix: fix error spam that occurs when the child process attempts to log certain data

### DIFF
--- a/src/socket-child.ts
+++ b/src/socket-child.ts
@@ -70,5 +70,5 @@ singleton.on(IPCMessageType.CommandTimeout, (commandId: number, trackingId: numb
 })
 
 function sendParentMessage (message: {cmd: IPCMessageType; payload?: any}) {
-	Util.sendIPCMessage(global, 'process', message, singleton.log).catch(() => { /* Discard errors. */ })
+	Util.sendIPCMessage(global, 'process', message, singleton.log.bind(singleton)).catch(() => { /* Discard errors. */ })
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix.


* **What is the current behavior?** (You can also link to an open issue here)
The child process spams this error over and over for the entire life of the socket. See #40.


* **What is the new behavior (if this is a feature change)?**
It doesn't error.


* **Other information**:
Helps #40.
