### PR TITLE
feat: add support for Media Pool settings

### DIFF
--- a/src/atem.ts
+++ b/src/atem.ts
@@ -721,4 +721,9 @@ export class Atem extends BasicAtem {
 			return []
 		}
 	}
+
+	public setMediaPoolSettings(props: Commands.MediaPoolProps): Promise<void> {
+		const command = new Commands.MediaPoolSettingsSetCommand(props.maxFrames)
+		return this.sendCommand(command)
+	}
 }

--- a/src/commands/Settings/MediaPool.ts
+++ b/src/commands/Settings/MediaPool.ts
@@ -1,5 +1,6 @@
 import { BasicWritableCommand, DeserializedCommand } from '../CommandBase'
 import { AtemState } from '../../state'
+import { ProtocolVersion } from '../../enums'
 
 export interface MediaPoolProps {
 	maxFrames: number[]
@@ -7,6 +8,7 @@ export interface MediaPoolProps {
 
 export class MediaPoolSettingsSetCommand extends BasicWritableCommand<MediaPoolProps> {
 	public static readonly rawName = 'CMPS'
+	public static readonly minimumVersion = ProtocolVersion.V8_0
 
 	constructor(maxFrames: number[]) {
 		super({ maxFrames })
@@ -24,6 +26,7 @@ export class MediaPoolSettingsSetCommand extends BasicWritableCommand<MediaPoolP
 
 export class MediaPoolSettingsGetCommand extends DeserializedCommand<MediaPoolProps & { unassignedFrames: number }> {
 	public static readonly rawName = 'MPSp'
+	public static readonly minimumVersion = ProtocolVersion.V8_0
 
 	constructor(maxFrames: number[], unassignedFrames: number) {
 		super({ maxFrames, unassignedFrames })

--- a/src/commands/Settings/MediaPool.ts
+++ b/src/commands/Settings/MediaPool.ts
@@ -42,8 +42,10 @@ export class MediaPoolSettingsGetCommand extends DeserializedCommand<MediaPoolPr
 	}
 
 	public applyToState(state: AtemState): string {
-		state.settings.mediaPool.maxFrames = this.properties.maxFrames
-		state.settings.mediaPool.unassignedFrames = this.properties.unassignedFrames
+		state.settings.mediaPool = {
+			maxFrames: this.properties.maxFrames,
+			unassignedFrames: this.properties.unassignedFrames
+		}
 		return `settings.mediaPool`
 	}
 }

--- a/src/commands/Settings/MediaPool.ts
+++ b/src/commands/Settings/MediaPool.ts
@@ -1,0 +1,49 @@
+import { BasicWritableCommand, DeserializedCommand } from '../CommandBase'
+import { AtemState } from '../../state'
+
+export interface MediaPoolProps {
+	maxFrames: number[]
+}
+
+export class MediaPoolSettingsSetCommand extends BasicWritableCommand<MediaPoolProps> {
+	public static readonly rawName = 'CMPS'
+
+	constructor(maxFrames: number[]) {
+		super({ maxFrames })
+	}
+
+	public serialize(): Buffer {
+		const buffer = Buffer.alloc(8)
+		buffer.writeUInt16BE(this.properties.maxFrames[0] || 0, 0)
+		buffer.writeUInt16BE(this.properties.maxFrames[1] || 0, 2)
+		buffer.writeUInt16BE(this.properties.maxFrames[2] || 0, 4)
+		buffer.writeUInt16BE(this.properties.maxFrames[3] || 0, 6)
+		return buffer
+	}
+}
+
+export class MediaPoolSettingsGetCommand extends DeserializedCommand<MediaPoolProps & { unassignedFrames: number }> {
+	public static readonly rawName = 'MPSp'
+
+	constructor(maxFrames: number[], unassignedFrames: number) {
+		super({ maxFrames, unassignedFrames })
+	}
+
+	public static deserialize(rawCommand: Buffer): MediaPoolSettingsGetCommand {
+		return new MediaPoolSettingsGetCommand(
+			[
+				rawCommand.readUInt16BE(0),
+				rawCommand.readUInt16BE(2),
+				rawCommand.readUInt16BE(4),
+				rawCommand.readUInt16BE(6)
+			],
+			rawCommand.readUInt16BE(8)
+		)
+	}
+
+	public applyToState(state: AtemState): string {
+		state.settings.mediaPool.maxFrames = this.properties.maxFrames
+		state.settings.mediaPool.unassignedFrames = this.properties.unassignedFrames
+		return `settings.mediaPool`
+	}
+}

--- a/src/commands/Settings/index.ts
+++ b/src/commands/Settings/index.ts
@@ -1,2 +1,3 @@
+export * from './MediaPool'
 export * from './MultiViewerSourceCommand'
 export * from './VideoMode'

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -18,7 +18,13 @@ export interface MultiViewer {
 	readonly windows: Array<MultiViewerWindowState | undefined>
 }
 
+export interface MediaPool {
+	maxFrames: number[]
+	unassignedFrames: number
+}
+
 export interface SettingsState {
 	readonly multiViewers: Array<MultiViewer | undefined>
 	videoMode: VideoMode
+	mediaPool: MediaPool
 }

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -26,5 +26,5 @@ export interface MediaPool {
 export interface SettingsState {
 	readonly multiViewers: Array<MultiViewer | undefined>
 	videoMode: VideoMode
-	mediaPool: MediaPool
+	mediaPool?: MediaPool
 }

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -40,7 +40,11 @@ export function Create(): AtemState {
 		},
 		settings: {
 			multiViewers: [],
-			videoMode: 0
+			videoMode: 0,
+			mediaPool: {
+				maxFrames: [0, 0, 0, 0],
+				unassignedFrames: 0
+			}
 		}
 	}
 }

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -41,10 +41,7 @@ export function Create(): AtemState {
 		settings: {
 			multiViewers: [],
 			videoMode: 0,
-			mediaPool: {
-				maxFrames: [0, 0, 0, 0],
-				unassignedFrames: 0
-			}
+			mediaPool: undefined
 		}
 	}
 }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
It adds support for the Media Pool settings, which is this part of the ATEM Software Control UI:
![image](https://user-images.githubusercontent.com/873012/141816151-34ca9be1-03c8-48b2-849f-ec2143fb0dd9.png)


* **What is the current behavior?** (You can also link to an open issue here)
These commands (`CMPS` and `MPSp`) are unsupported.


* **What is the new behavior (if this is a feature change)?**
These commands are supported.


* **Other information**:
At this time, tests are not passing. I'm unsure why. Help/guidance would be appreciated.
