### PR TITLE
feat: add support for using generators with uploadClip

### DIFF
--- a/examples/testUtils/generate-data-transfer-spec.ts
+++ b/examples/testUtils/generate-data-transfer-spec.ts
@@ -35,9 +35,9 @@ nb.on('connected', async () => {
 		})
 	})
 	nb.on('receivedCommands', (cmds) => {
-		cmds.forEach((cmd): void => {
+		cmds.forEach(async (cmd): Promise<void> => {
 			commands.push(procCmd(cmd, 'recv'))
-			transfer.handleCommand(cmd)
+			await transfer.handleCommand(cmd)
 		})
 	})
 

--- a/examples/testUtils/generate-data-transfer-spec.ts
+++ b/examples/testUtils/generate-data-transfer-spec.ts
@@ -37,7 +37,7 @@ nb.on('connected', async () => {
 	nb.on('receivedCommands', (cmds) => {
 		cmds.forEach(async (cmd): Promise<void> => {
 			commands.push(procCmd(cmd, 'recv'))
-			await transfer.handleCommand(cmd)
+			transfer.queueCommand(cmd)
 		})
 	})
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eventemitter3": "^4.0.7",
     "exit-hook": "^2.2.1",
     "nanotimer": "^0.3.15",
+    "p-queue": "^6.6.2",
     "threadedclass": "^0.9.0",
     "tslib": "^2.2.0",
     "wavefile": "^8.4.4"

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -202,14 +202,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 
 			for (const commandName in DataTransferCommands) {
 				if (command.constructor.name === commandName) {
-					this.dataTransferManager.handleCommand(command).catch((e) => {
-						this.emit(
-							'error',
-							`Data transfer command handling failed: ${e}. Command: ${
-								command.constructor.name
-							} ${Util.commandStringify(command)}`
-						)
-					})
+					this.dataTransferManager.queueCommand(command)
 				}
 			}
 		}

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -204,7 +204,14 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 
 			for (const commandName in DataTransferCommands) {
 				if (command.constructor.name === commandName) {
-					await this.dataTransferManager.handleCommand(command)
+					this.dataTransferManager.handleCommand(command).catch((e) => {
+						this.emit(
+							'error',
+							`MutateState failed: ${e}. Command: ${command.constructor.name} ${Util.commandStringify(
+								command
+							)}`
+						)
+					})
 				}
 			}
 		}

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -172,7 +172,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		const allChangedPaths: string[] = []
 
 		const state = this._state
-		commands.forEach((command) => {
+		commands.forEach(async (command) => {
 			if (state) {
 				try {
 					const changePaths = command.applyToState(state)
@@ -202,7 +202,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 
 			for (const commandName in DataTransferCommands) {
 				if (command.constructor.name === commandName) {
-					this.dataTransferManager.handleCommand(command)
+					await this.dataTransferManager.handleCommand(command)
 				}
 			}
 		})
@@ -671,15 +671,20 @@ export class Atem extends BasicAtem {
 		)
 	}
 
-	public uploadClip(index: number, frames: Array<Buffer>, name: string): Promise<DataTransfer> {
+	public uploadClip(
+		index: number,
+		frames: Iterable<Buffer> | AsyncIterable<Buffer>,
+		name: string
+	): Promise<DataTransfer> {
 		if (!this.state) return Promise.reject()
 		const resolution = Util.getVideoModeInfo(this.state.settings.videoMode)
 		if (!resolution) return Promise.reject()
-		const data: Array<Buffer> = []
-		for (const frame of frames) {
-			data.push(Util.convertRGBAToYUV422(resolution.width, resolution.height, frame))
+		const provideFrame = async function* (): AsyncGenerator<Buffer> {
+			for await (const frame of frames) {
+				yield Util.convertRGBAToYUV422(resolution.width, resolution.height, frame)
+			}
 		}
-		return this.dataTransferManager.uploadClip(index, data, name)
+		return this.dataTransferManager.uploadClip(index, provideFrame(), name)
 	}
 
 	public uploadAudio(index: number, data: Buffer, name: string): Promise<DataTransfer> {

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -96,9 +96,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 
 		this.socket.on('commandsReceived', (commands) => {
 			this.emit('receivedCommands', commands)
-			this._mutateState(commands).catch((error) => {
-				this.emit('error', error)
-			})
+			this._mutateState(commands)
 		})
 		this.socket.on('commandsAck', (trackingIds) => this._resolveCommands(trackingIds))
 		this.socket.on('info', (msg) => this.emit('info', msg))
@@ -163,7 +161,7 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 		return this.sendCommands([command])[0]
 	}
 
-	private async _mutateState(commands: IDeserializedCommand[]): Promise<void> {
+	private _mutateState(commands: IDeserializedCommand[]): void {
 		// Is this the start of a new connection?
 		if (commands.find((cmd) => cmd.constructor.name === Commands.VersionCommand.name)) {
 			// On start of connection, create a new state object

--- a/src/atem.ts
+++ b/src/atem.ts
@@ -207,9 +207,9 @@ export class BasicAtem extends EventEmitter<AtemEvents> {
 					this.dataTransferManager.handleCommand(command).catch((e) => {
 						this.emit(
 							'error',
-							`MutateState failed: ${e}. Command: ${command.constructor.name} ${Util.commandStringify(
-								command
-							)}`
+							`Data transfer command handling failed: ${e}. Command: ${
+								command.constructor.name
+							} ${Util.commandStringify(command)}`
 						)
 					})
 				}

--- a/src/dataTransfer/__tests__/index.spec.ts
+++ b/src/dataTransfer/__tests__/index.spec.ts
@@ -34,7 +34,7 @@ function mangleCommand(cmd: any, dir: string): any {
 function runDataTransferTest(spec: any): DataTransferManager {
 	const manager = new DataTransferManager()
 	manager.startCommandSending((cmds) =>
-		cmds.map((cmd) => {
+		cmds.map(async (cmd) => {
 			const expectedCmd = spec.shift()
 			const gotCmd = mangleCommand(cmd, 'send')
 			expect(expectedCmd).toEqual(gotCmd)
@@ -44,7 +44,7 @@ function runDataTransferTest(spec: any): DataTransferManager {
 				const nextCmd = spec.shift()
 				const nextCmd2 = specToCommandClass(nextCmd)
 				if (!nextCmd2) throw new Error(`Failed specToCommandClass ${nextCmd.name}`)
-				manager.handleCommand(nextCmd2)
+				await manager.handleCommand(nextCmd2)
 			}
 
 			return Promise.resolve()

--- a/src/dataTransfer/__tests__/index.spec.ts
+++ b/src/dataTransfer/__tests__/index.spec.ts
@@ -34,7 +34,7 @@ function mangleCommand(cmd: any, dir: string): any {
 function runDataTransferTest(spec: any): DataTransferManager {
 	const manager = new DataTransferManager()
 	manager.startCommandSending((cmds) =>
-		cmds.map(async (cmd) => {
+		cmds.map((cmd) => {
 			const expectedCmd = spec.shift()
 			const gotCmd = mangleCommand(cmd, 'send')
 			expect(expectedCmd).toEqual(gotCmd)
@@ -44,7 +44,7 @@ function runDataTransferTest(spec: any): DataTransferManager {
 				const nextCmd = spec.shift()
 				const nextCmd2 = specToCommandClass(nextCmd)
 				if (!nextCmd2) throw new Error(`Failed specToCommandClass ${nextCmd.name}`)
-				await manager.handleCommand(nextCmd2)
+				manager.queueCommand(nextCmd2)
 			}
 
 			return Promise.resolve()

--- a/src/dataTransfer/dataLock.ts
+++ b/src/dataTransfer/dataLock.ts
@@ -36,7 +36,10 @@ export default class DataLock {
 
 			if (this.isLocked) {
 				// TODO - this flow should never be hit
-				void this.lockObtained()
+				this.lockObtained().catch((e) => {
+					// TODO - handle this better. it should kill/restart the upload. and should also be logged in some way
+					console.error(`Error after obtaining lock: ${e}`)
+				})
 			} else {
 				this.queueCommand(new Commands.LockStateCommand(this.storeId, true))
 			}
@@ -81,7 +84,7 @@ export default class DataLock {
 					if (this.activeTransfer instanceof DataTransferClip) {
 						// Retry the last frame.
 						if (this.activeTransfer.curFrame) {
-							this.activeTransfer.curFrame.start().forEach((cmd) => this.queueCommand(cmd))
+							;(await this.activeTransfer.curFrame.start()).forEach((cmd) => this.queueCommand(cmd))
 						}
 					} else {
 						// Retry the entire transfer.

--- a/src/dataTransfer/dataTransfer.ts
+++ b/src/dataTransfer/dataTransfer.ts
@@ -35,8 +35,10 @@ export default abstract class DataTransfer {
 		return this.completionPromise
 	}
 
-	public abstract start(): Commands.ISerializableCommand[]
+	public abstract start(): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
 
-	public abstract handleCommand(command: Commands.IDeserializedCommand): Commands.ISerializableCommand[]
-	public abstract gotLock(): Commands.ISerializableCommand[]
+	public abstract handleCommand(
+		command: Commands.IDeserializedCommand
+	): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
+	public abstract gotLock(): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
 }

--- a/src/dataTransfer/dataTransfer.ts
+++ b/src/dataTransfer/dataTransfer.ts
@@ -35,10 +35,8 @@ export default abstract class DataTransfer {
 		return this.completionPromise
 	}
 
-	public abstract start(): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
+	public abstract start(): Promise<Commands.ISerializableCommand[]>
 
-	public abstract handleCommand(
-		command: Commands.IDeserializedCommand
-	): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
-	public abstract gotLock(): Commands.ISerializableCommand[] | Promise<Commands.ISerializableCommand[]>
+	public abstract handleCommand(command: Commands.IDeserializedCommand): Promise<Commands.ISerializableCommand[]>
+	public abstract gotLock(): Promise<Commands.ISerializableCommand[]>
 }

--- a/src/dataTransfer/dataTransferAudio.ts
+++ b/src/dataTransfer/dataTransferAudio.ts
@@ -11,7 +11,7 @@ export default class DataTransferAudio extends DataTransferFrame {
 		this.name = name
 	}
 
-	public start(): Commands.ISerializableCommand[] {
+	public async start(): Promise<Commands.ISerializableCommand[]> {
 		const command = new Commands.DataTransferUploadRequestCommand({
 			transferId: this.transferId,
 			transferStoreId: this.storeId,

--- a/src/dataTransfer/dataTransferClip.ts
+++ b/src/dataTransfer/dataTransferClip.ts
@@ -71,7 +71,7 @@ export default class DataTransferClip extends DataTransfer {
 
 	get transferId(): number {
 		if (!this.curFrame) {
-			throw new Error('Current frame not ready')
+			return this._transferId
 		}
 
 		return this.curFrame.transferId

--- a/src/dataTransfer/dataTransferClip.ts
+++ b/src/dataTransfer/dataTransferClip.ts
@@ -5,11 +5,16 @@ import DataTransferFrame from './dataTransferFrame'
 
 export default class DataTransferClip extends DataTransfer {
 	public readonly clipIndex: number // 0 or 1
-	public readonly frames: Array<DataTransferFrame>
+	public readonly frames: Generator<DataTransferFrame> | AsyncGenerator<DataTransferFrame>
 	public readonly name: string
-	public curFrame = 0
+	public curFrame: DataTransferFrame | undefined
+	private numFrames = 0
 
-	constructor(clipIndex: number, name: string, frames: Array<DataTransferFrame>) {
+	constructor(
+		clipIndex: number,
+		name: string,
+		frames: Generator<DataTransferFrame> | AsyncGenerator<DataTransferFrame>
+	) {
 		super(0, 1 + clipIndex)
 
 		this.clipIndex = clipIndex
@@ -17,29 +22,38 @@ export default class DataTransferClip extends DataTransfer {
 		this.frames = frames
 	}
 
-	public start(): Commands.ISerializableCommand[] {
+	public async start(): Promise<Commands.ISerializableCommand[]> {
 		const commands: Commands.ISerializableCommand[] = []
 		commands.push(new Commands.MediaPoolClearClipCommand(this.clipIndex))
-		this.frames[this.curFrame].state = Enums.TransferState.Locked
-		commands.push(...this.frames[this.curFrame].start())
+		this.curFrame = await (await this.frames.next()).value
+		if (!this.curFrame) {
+			throw new Error('No frames available for transfer')
+		}
+		this.numFrames++
+		this.curFrame.state = Enums.TransferState.Locked
+		commands.push(...this.curFrame.start())
 		return commands
 	}
 
-	public handleCommand(command: Commands.IDeserializedCommand): Commands.ISerializableCommand[] {
+	public async handleCommand(command: Commands.IDeserializedCommand): Promise<Commands.ISerializableCommand[]> {
 		const commands: Commands.ISerializableCommand[] = []
 
-		commands.push(...this.frames[this.curFrame].handleCommand(command))
+		if (!this.curFrame) {
+			throw new Error('No frames available for transfer')
+		}
+		commands.push(...this.curFrame.handleCommand(command))
 		if (this.state !== Enums.TransferState.Transferring) this.state = Enums.TransferState.Transferring
-		if (this.frames[this.curFrame].state === Enums.TransferState.Finished) {
-			this.curFrame++
-			if (this.curFrame < this.frames.length) {
-				this.frames[this.curFrame].state = Enums.TransferState.Locked
-				commands.push(...this.frames[this.curFrame].start())
+		if (this.curFrame.state === Enums.TransferState.Finished) {
+			this.curFrame = await (await this.frames.next()).value
+			if (this.curFrame) {
+				this.numFrames++
+				this.curFrame.state = Enums.TransferState.Locked
+				commands.push(...this.curFrame.start())
 			} else {
 				const command = new Commands.MediaPoolSetClipCommand({
 					index: this.clipIndex,
 					name: this.name,
-					frames: this.frames.length,
+					frames: this.numFrames,
 				})
 				commands.push(command)
 				this.state = Enums.TransferState.Finished
@@ -50,10 +64,14 @@ export default class DataTransferClip extends DataTransfer {
 	}
 
 	get transferId(): number {
-		return this.frames[this.curFrame].transferId
+		if (!this.curFrame) {
+			throw new Error('Current frame not ready')
+		}
+
+		return this.curFrame.transferId
 	}
 
-	public gotLock(): Commands.ISerializableCommand[] {
+	public gotLock(): Promise<Commands.ISerializableCommand[]> {
 		this.state = Enums.TransferState.Locked
 		return this.start()
 	}

--- a/src/dataTransfer/dataTransferFrame.ts
+++ b/src/dataTransfer/dataTransferFrame.ts
@@ -18,7 +18,7 @@ export default class DataTransferFrame extends DataTransfer {
 		this.hash = this.data ? crypto.createHash('md5').update(this.data).digest().toString() : ''
 	}
 
-	public start(): Commands.ISerializableCommand[] {
+	public async start(): Promise<Commands.ISerializableCommand[]> {
 		const command = new Commands.DataTransferUploadRequestCommand({
 			transferId: this.transferId,
 			transferStoreId: this.storeId,
@@ -33,7 +33,7 @@ export default class DataTransferFrame extends DataTransfer {
 		return new Commands.DataTransferFileDescriptionCommand({ fileHash: this.hash, transferId: this.transferId })
 	}
 
-	public handleCommand(command: Commands.IDeserializedCommand): Commands.ISerializableCommand[] {
+	public async handleCommand(command: Commands.IDeserializedCommand): Promise<Commands.ISerializableCommand[]> {
 		const commands: Commands.ISerializableCommand[] = []
 		if (command.constructor.name === Commands.DataTransferUploadContinueCommand.name) {
 			if (this.state === Enums.TransferState.Locked) {
@@ -50,7 +50,7 @@ export default class DataTransferFrame extends DataTransfer {
 		return commands
 	}
 
-	public gotLock(): Commands.ISerializableCommand[] {
+	public async gotLock(): Promise<Commands.ISerializableCommand[]> {
 		this.state = Enums.TransferState.Locked
 		return this.start()
 	}

--- a/src/dataTransfer/index.ts
+++ b/src/dataTransfer/index.ts
@@ -64,7 +64,7 @@ export class DataTransferManager {
 		}
 	}
 
-	public async handleCommand(command: Commands.IDeserializedCommand): Promise<void> {
+	public queueCommand(command: Commands.IDeserializedCommand): void {
 		this.pQueue
 			.add(async () => {
 				const allLocks = [this.stillsLock, ...this.clipLocks]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4489,6 +4489,21 @@ p-map@^4.0.0:
   dependencies:
     aggregate-error "^3.0.0"
 
+p-queue@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
+
 p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
`uploadClip` only accepts an array of RGBA framebuffers.


* **What is the new behavior (if this is a feature change)?**
`uploadClip` now also accepts a (synchronous) [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*). Example usage:
```js
/*
Movie to tga sequence
ffmpeg -i inFileName.mov outFileName%03d.tga

Convert image-sequence (unix one-line bash)
for i in *.tga; do ffmpeg -i "$i" -pix_fmt rgba -f rawvideo "$(basename "$i" .tga)".rgba  ; done
*/
// Edit this to be a path on your computer that points to a directory of raw *.rgba image files
const SOURCE_PATH = 'C:\\Users\\vanca\\Desktop\\source\\sequence_short'

// Edit this to point to your ATEM
const ATEM_HOST = '192.168.1.5'

const fs = require('fs')
const path = require('path')
const { Atem } = require('atem-connection')

const allRGBAs = fs.readdirSync(SOURCE_PATH).filter(filename => {
	return filename.endsWith('.rgba')
}).map(filename => {
	return path.join(SOURCE_PATH, filename)
})

let frameNum = -1;
const provideFrame = function* () {
	const startTime = Date.now()
	for (const rgba of allRGBAs) {
		frameNum++
		console.log('Processing frame #%d (%s)', frameNum, rgba)
		yield fs.readFileSync(rgba)
	}

	const endTime = Date.now()
	console.log('Processing complete in %d seconds', (endTime - startTime) / 1000)
}

async function start() {
	const atem = new Atem();
	await atem.connect(ATEM_HOST)
	await sleep(1000) // Not sure why this is necessary, but it is...
	await atem.uploadClip(0, provideFrame(), 'clip0')
	process.exit(0)
}

async function sleep(duration) {
	return new Promise(resolve => {
		setTimeout(() => resolve(), duration)
	})
}

start().catch(error => console.error(error))
```


* **Other information**:
Support for async generators seems much more complex and would require a larger refactor of the data transfer system. It would also mean removing support for Node 8, as async generators only became available in Node 10.

Helps address https://github.com/nrkno/tv-automation-atem-connection/issues/110